### PR TITLE
Added link to dev.to article

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,3 @@
 # Travis-blog
 [![Build Status](https://travis-ci.org/lauragift21/travis-blog.svg?branch=master)](https://travis-ci.org/lauragift21/travis-blog)  
-Code for  blogpost on [CI setup with travis and Nodejs](https://giftegwuenu.com/setup-continuous-integration-with-travis-ci-in-your-nodejs-app/)
+Code for  blogpost on [CI setup with travis and Nodejs](https://giftegwuenu.com/setup-continuous-integration-with-travis-ci-in-your-nodejs-app/) or the repost at [dev.to](https://dev.to/lauragift21/setup-continuous-integration-with-travis-ci-in-your-nodejs-app-26i2)


### PR DESCRIPTION
I found your great post via dev.to, which links to this repository, but not the other way around, so I am proposing this minor edit. I am still processing the contents of your article and I _might_ get back to you with comments, which leads me to a question - I can comment on dev.to, but I cannot seem to comment [on your blog](https://www.giftegwuenu.com/setup-continuous-integration-with-travis-ci-in-your-nodejs-app/) - I am missing something?